### PR TITLE
Move to chainguard node-lts image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:21-slim@sha256:2bf48899bbba183a33b362842c9a9832f19c99896159551f9a0420c53ec27522 as build
+# syntax=docker/dockerfile:1
+FROM chainguard/node-lts@sha256:e8a45ba91e4498c23a49175508f725db87c2e4a1178e3573713f781527dea983 as build
 
 WORKDIR /app
 
@@ -9,9 +10,9 @@ RUN npm ci --production
 COPY . .
 
 
-FROM node:21-slim@sha256:2bf48899bbba183a33b362842c9a9832f19c99896159551f9a0420c53ec27522 as release
+FROM chainguard/node-lts@sha256:e8a45ba91e4498c23a49175508f725db87c2e4a1178e3573713f781527dea983 as release
 
-# Switch to non-root user uid=1000(node)
+# Switch to non-root user uid=65532(node)
 USER node
 
 # Set environment variables
@@ -19,11 +20,11 @@ ENV NPM_CONFIG_LOGLEVEL=warn
 ENV NODE_ENV=production
 
 # Change working directory
-WORKDIR /home/node
+WORKDIR /app
 
 # Copy app directory from build stage
-COPY --chown=node:node --from=build /app .
+COPY --link --chown=node:node --from=build /app .
 
 EXPOSE 3001
 
-CMD ["node", "src/index.js"]
+CMD ["src/index.js"]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SHA256 digest pinning is used to achieve reliable and reproducable builds. Using
 ### Docker image and npm dependency updates
 In order to receive Docker image and npm dependency updates [Renovate](https://docs.renovatebot.com) is used to create a pull request when: 
 
-- Newer digest from [node:20-slim](https://hub.docker.com/_/node?tab=tags&page=1&name=20-slim) is available on Docker Hub 
+- Newer digest from [chainguard/node-lts](https://hub.docker.com/r/chainguard/node-lts/tags) is available on Docker Hub 
 - `Minor` or `Patch` update of a npm dependency is available 
 
 ### Vulnerability scanning

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         image: IMAGE_NAME
         imagePullPolicy: IfNotPresent
         securityContext:
-          runAsUser: 1000 # node
+          runAsUser: 65532 # node
           runAsNonRoot: true
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false


### PR DESCRIPTION
- Move from `node:21-slim` to `chainguard/node-lts` image
- Update `node` user id
- Use `COPY --link` to accelerate image builds