### PR TITLE
Fix COPY --link problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV NODE_ENV=production
 WORKDIR /app
 
 # Copy app directory from build stage
-COPY --link --chown=node:node --from=build /app .
+COPY --link --chown=65532 --from=build /app .
 
 EXPOSE 3001
 


### PR DESCRIPTION
Use user id instead of username when using `COPY --link --chown`